### PR TITLE
Fix typos in project pages

### DIFF
--- a/paraxial_fluids_of_light.html
+++ b/paraxial_fluids_of_light.html
@@ -136,7 +136,7 @@
                         <div class="member-image">
                             <img src="img/teams/vicente_rocha.jpg" alt="Vicente Rocha" class="team-img">
                         </div>
-                        <h4 class="member-name">Mr. Vicent Rocha</h4>
+                        <h4 class="member-name">Mr. Vicente Rocha</h4>
                         <p class="member-role">PhD Student</p>
                     </div>
                     

--- a/spectral_imaging.html
+++ b/spectral_imaging.html
@@ -293,7 +293,7 @@
             <div class="publication-compact">
                 <h4 class="publication-title">Automation And Sample Classification Algorithms For Industrial Spectroscopy-Based Systems </h4>
                 <p class="publication-authors">João Caramelo</p>
-                <p class="publication-journal">University of Porto &bull; <span class="publication-year">Exptected 2025</span></p>
+                <p class="publication-journal">University of Porto &bull; <span class="publication-year">Expected 2025</span></p>
             </div>
 
             <div class="publication-compact">


### PR DESCRIPTION
## Summary
- fix "Exptected" typo in Spectral Imaging page
- fix name of PhD student Vicente Rocha on the Paraxial Fluids of Light page

## Testing
- `grep -n Exptected spectral_imaging.html`
- `grep -n Vicent paraxial_fluids_of_light.html`

------
https://chatgpt.com/codex/tasks/task_e_6842ab48ce3c832a9008522dde67bee4